### PR TITLE
Feature/ft exit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/05/12 14:11:43 by jeonghwl          #+#    #+#              #
-#    Updated: 2022/05/14 21:43:23 by hkim2            ###   ########.fr        #
+#    Updated: 2022/05/14 23:30:27 by hkim2            ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -47,6 +47,7 @@ SRC 		= 	srcs/ft_tmp.c \
 				srcs/execute/ft_cd.c \
 				srcs/execute/ft_cd_util.c \
 				srcs/execute/ft_echo.c \
+				srcs/execute/ft_exit.c \
 				
 OBJ_DIR 	= objs
 OBJ 		= $(SRC:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/05/12 14:11:43 by jeonghwl          #+#    #+#              #
-#    Updated: 2022/05/12 22:35:59 by hkim2            ###   ########.fr        #
+#    Updated: 2022/05/13 00:56:29 by hkim2            ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -14,7 +14,7 @@
 CC 				= gcc
 RM				= rm -rf
 #-Werror을 하면 not uses가 떠서 잠시 주석처리
-CFLAGS 			= -Wall -Wextra #-Werror
+CFLAGS 			= -Wall -Wextra -g -fsanitize=address#-Werror
 NAME 			= minishell
 
 READLINE_LIB 	= -lreadline -L/usr/local/opt/readline/lib
@@ -42,7 +42,8 @@ SRC 		= 	srcs/ft_tmp.c \
 				srcs/execute/ft_env.c \
 				srcs/execute/ft_pwd.c \
 				srcs/execute/ft_export.c \
-				srcs/execute/ft_export_util.c
+				srcs/execute/ft_export_util.c \
+				srcs/execute/ft_unset.c \
 				
 OBJ_DIR 	= objs
 OBJ 		= $(SRC:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/05/12 14:11:43 by jeonghwl          #+#    #+#              #
-#    Updated: 2022/05/14 00:02:05 by hkim2            ###   ########.fr        #
+#    Updated: 2022/05/14 21:43:23 by hkim2            ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -46,6 +46,7 @@ SRC 		= 	srcs/ft_tmp.c \
 				srcs/execute/ft_unset.c \
 				srcs/execute/ft_cd.c \
 				srcs/execute/ft_cd_util.c \
+				srcs/execute/ft_echo.c \
 				
 OBJ_DIR 	= objs
 OBJ 		= $(SRC:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/05/12 14:11:43 by jeonghwl          #+#    #+#              #
-#    Updated: 2022/05/13 00:56:29 by hkim2            ###   ########.fr        #
+#    Updated: 2022/05/14 00:02:05 by hkim2            ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -44,6 +44,8 @@ SRC 		= 	srcs/ft_tmp.c \
 				srcs/execute/ft_export.c \
 				srcs/execute/ft_export_util.c \
 				srcs/execute/ft_unset.c \
+				srcs/execute/ft_cd.c \
+				srcs/execute/ft_cd_util.c \
 				
 OBJ_DIR 	= objs
 OBJ 		= $(SRC:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/11 13:57:07 by jeonghwl          #+#    #+#             */
-/*   Updated: 2022/05/14 20:09:00 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/14 21:52:36 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -241,4 +241,9 @@ int					execute_home(t_cmd *cmd_list, char ***env, char *home, char *path);
 int					print_cd_error(char *cmd);
 int					add_cd_env(char *current_pwd, char *old_pwd, char ***env);
 
+//execute/ft_echo.c
+int					ft_echo(t_cmd *cmd_list);
+void				print_echo(t_cmd *cmd_list);
+void				print_echo_no_newline(t_cmd *cmd_list);
+int					check_newline(char *cmd);
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/11 13:57:07 by jeonghwl          #+#    #+#             */
-/*   Updated: 2022/05/14 21:52:36 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/14 23:31:25 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,6 +24,7 @@
 # include <sys/stat.h>
 # include "../libft/libft.h"
 # include <signal.h>
+# include <string.h>
 
 # define STDIN 			0
 # define STDOUT 		1
@@ -246,4 +247,11 @@ int					ft_echo(t_cmd *cmd_list);
 void				print_echo(t_cmd *cmd_list);
 void				print_echo_no_newline(t_cmd *cmd_list);
 int					check_newline(char *cmd);
+
+//execute/ft_exit.c
+int					ft_exit(t_cmd *cmd_list);
+int					execute_exit(t_cmd *cmd_list);
+void				print_exit_many_arg();
+void				print_exit_numeric(char *cmd);
+int					is_numeric(char *cmd);
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/11 13:57:07 by jeonghwl          #+#    #+#             */
-/*   Updated: 2022/05/13 18:28:48 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/14 00:03:52 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,6 +43,10 @@
 
 # define CLOSED 1
 # define UNCLOSED 0
+
+# define CD_ERROR 0
+# define CD_HOME 1
+# define CD_ARG 2
 
 extern int	g_exit_status;
 
@@ -217,11 +221,23 @@ void				free_split_str(char **str);
 int					is_vaild_word(char c);
 int					add_duplicate_key(char *cmd, char ***env);
 int					get_duplicate_index(char *cmd, char **env);
+
 //execute/ft_unset.c
 int					ft_unset(t_cmd *cmd_list, char ***env);
 void				print_unset_error(char *cmd);
 int					valid_unset_cmd(char *cmd);
 int					get_removal_index(char *cmd, char **env);
 void				remove_env(char *cmd, char ***env);
+
+//execute/ft_cd.c
+int					ft_cd(t_cmd *cmd_list, char ***env);
+int					execute_chdir(char ***env, char *path);
+int					execute_env(t_cmd *cmd_list, char ***env, char *home, char *path);
+int					execute_none_option(t_cmd *cmd_list, char ***env, char *home);
+int					execute_home(t_cmd *cmd_list, char ***env, char *home, char *path);
+
+//execute/ft_cd_util.c
+int					print_cd_error(char *cmd);
+int					add_cd_env(char *current_pwd, char *old_pwd, char ***env);
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/11 13:57:07 by jeonghwl          #+#    #+#             */
-/*   Updated: 2022/05/14 00:03:52 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/14 20:09:00 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -221,6 +221,7 @@ void				free_split_str(char **str);
 int					is_vaild_word(char c);
 int					add_duplicate_key(char *cmd, char ***env);
 int					get_duplicate_index(char *cmd, char **env);
+int					add_new_value(char *cmd, char ***env);
 
 //execute/ft_unset.c
 int					ft_unset(t_cmd *cmd_list, char ***env);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/11 13:57:07 by jeonghwl          #+#    #+#             */
-/*   Updated: 2022/05/12 23:01:06 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/13 18:28:48 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -210,9 +210,18 @@ int					ft_export(t_cmd *cmd_list, char ***env);
 void				print_export(char **env);
 void				free_split_str(char **str);
 void				print_export_error(char *cmd);
-void				add_env(char *cmd, char ***env);
+int					add_env(char *cmd, char ***env);
 
 //execute/export_util
 void				free_split_str(char **str);
 int					is_vaild_word(char c);
+int					add_duplicate_key(char *cmd, char ***env);
+int					get_duplicate_index(char *cmd, char **env);
+//execute/ft_unset.c
+int					ft_unset(t_cmd *cmd_list, char ***env);
+void				print_unset_error(char *cmd);
+int					valid_unset_cmd(char *cmd);
+int					get_removal_index(char *cmd, char **env);
+void				remove_env(char *cmd, char ***env);
+
 #endif

--- a/srcs/execute/execute.c
+++ b/srcs/execute/execute.c
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/10 19:43:23 by hkim2             #+#    #+#             */
-/*   Updated: 2022/05/12 21:40:20 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/13 00:13:36 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,6 +43,7 @@ void	execute(t_cmd *cmd_list, char ***env)
 
 	path = get_cmd_path(*env);
 	i = 0;
+	
 	while (cmd_list)
 	{
 		if (cmd_list->pipe_flag)
@@ -51,8 +52,6 @@ void	execute(t_cmd *cmd_list, char ***env)
 		{
 			if (exec_builtin(cmd_list, env))
 				return ;
-			//printf("build in error\n");
-			
 		}
 		cmd_list = cmd_list->next;
 	}	

--- a/srcs/execute/execute_builtin.c
+++ b/srcs/execute/execute_builtin.c
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/12 18:07:33 by hkim2             #+#    #+#             */
-/*   Updated: 2022/05/14 21:40:26 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/14 23:32:42 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,6 +46,6 @@ int		exec_builtin(t_cmd *cmd_list, char ***env)
 	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "unset", 6) == 0)
 		return (ft_unset(cmd_list, env));
 	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "exit", 5) == 0)
-		return (EXIT_SUCCESS);
+		return (ft_exit(cmd_list));
 	return (EXIT_FAILURE);	
 }

--- a/srcs/execute/execute_builtin.c
+++ b/srcs/execute/execute_builtin.c
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/12 18:07:33 by hkim2             #+#    #+#             */
-/*   Updated: 2022/05/13 22:17:07 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/14 21:40:26 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,7 +38,7 @@ int		exec_builtin(t_cmd *cmd_list, char ***env)
 	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "pwd", 4) == 0)
 		return (ft_pwd(cmd_list));
 	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "echo", 5) == 0)
-		return (EXIT_SUCCESS);
+		return (ft_echo(cmd_list));
 	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "env", 4) == 0)
 		return (ft_env(*env));
 	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "export", 7) == 0)

--- a/srcs/execute/execute_builtin.c
+++ b/srcs/execute/execute_builtin.c
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/12 18:07:33 by hkim2             #+#    #+#             */
-/*   Updated: 2022/05/12 23:38:14 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/13 22:17:07 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,38 +14,38 @@
 
 int		is_builtin(char *cmd)
 {
-	if (ft_strncmp(cmd, "cd", 2) == 0)
+	if (ft_strncmp(cmd, "cd", 3) == 0)
 		return (1);
-	if (ft_strncmp(cmd, "pwd", 3) == 0)
+	if (ft_strncmp(cmd, "pwd", 4) == 0)
 		return (1);
-	if (ft_strncmp(cmd, "echo", 4) == 0)
+	if (ft_strncmp(cmd, "echo", 5) == 0)
 		return (1);
-	if (ft_strncmp(cmd, "env", 3) == 0)
+	if (ft_strncmp(cmd, "env", 4) == 0)
 		return (1);
-	if (ft_strncmp(cmd, "export", 6) == 0)
+	if (ft_strncmp(cmd, "export", 7) == 0)
 		return (1);
-	if (ft_strncmp(cmd, "unset", 5) == 0)
+	if (ft_strncmp(cmd, "unset", 6) == 0)
 		return (1);
-	if (ft_strncmp(cmd, "exit", 4) == 0)
+	if (ft_strncmp(cmd, "exit", 5) == 0)
 		return (1);
 	return (0);	
 }
 
 int		exec_builtin(t_cmd *cmd_list, char ***env)
 {
-	if (ft_strncmp(cmd_list->cmdline[0].cmd, "cd", 2) == 0)
-		return (EXIT_SUCCESS);
-	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "pwd", 3) == 0)
+	if (ft_strncmp(cmd_list->cmdline[0].cmd, "cd", 3) == 0)
+		return (ft_cd(cmd_list, env));
+	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "pwd", 4) == 0)
 		return (ft_pwd(cmd_list));
-	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "echo", 4) == 0)
+	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "echo", 5) == 0)
 		return (EXIT_SUCCESS);
-	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "env", 3) == 0)
+	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "env", 4) == 0)
 		return (ft_env(*env));
-	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "export", 6) == 0)
+	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "export", 7) == 0)
 		return (ft_export(cmd_list, env));
-	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "unset", 5) == 0)
+	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "unset", 6) == 0)
 		return (ft_unset(cmd_list, env));
-	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "exit", 4) == 0)
+	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "exit", 5) == 0)
 		return (EXIT_SUCCESS);
 	return (EXIT_FAILURE);	
 }

--- a/srcs/execute/execute_builtin.c
+++ b/srcs/execute/execute_builtin.c
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/12 18:07:33 by hkim2             #+#    #+#             */
-/*   Updated: 2022/05/12 21:28:30 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/12 23:38:14 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,7 +44,7 @@ int		exec_builtin(t_cmd *cmd_list, char ***env)
 	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "export", 6) == 0)
 		return (ft_export(cmd_list, env));
 	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "unset", 5) == 0)
-		return (EXIT_SUCCESS);
+		return (ft_unset(cmd_list, env));
 	else if (ft_strncmp(cmd_list->cmdline[0].cmd, "exit", 4) == 0)
 		return (EXIT_SUCCESS);
 	return (EXIT_FAILURE);	

--- a/srcs/execute/ft_cd.c
+++ b/srcs/execute/ft_cd.c
@@ -1,0 +1,96 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_cd.c                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/05/13 19:08:52 by hkim2             #+#    #+#             */
+/*   Updated: 2022/05/14 00:04:28 by hkim2            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+# include "../../includes/minishell.h"
+
+int	execute_chdir(char ***env, char *path)
+{
+	char	old_pwd[1024];
+	char	current_pwd[1024];
+
+	if (!getcwd(old_pwd, 1024))
+	{
+		//errono 에러 출력
+		return (EXIT_FAILURE);
+	}
+	if (chdir(path) == -1)
+	{
+		print_cd_error(path);
+		return (EXIT_FAILURE);
+	}
+	if (!getcwd(current_pwd, 1024))
+	{
+		//errono 에러 출력
+		return (EXIT_FAILURE);
+	}
+	return (add_cd_env(current_pwd, old_pwd, env));
+}
+
+int	execute_env(t_cmd *cmd_list, char ***env, char *home, char *path)
+{	
+	int	is_error;
+
+	is_error = EXIT_FAILURE;
+	path = cmd_list->cmdline[1].cmd;
+	
+	if (path != NULL && ft_strlen(path) == 0)
+		is_error = execute_chdir(env, home);
+	else
+		is_error = execute_chdir(env, path);
+	return (is_error);
+}
+
+int	execute_none_option(t_cmd *cmd_list, char ***env, char *home)
+{
+	int	is_error;
+
+	is_error = EXIT_FAILURE;
+	if (get_cmd_size(cmd_list) <= 1)
+		is_error = execute_chdir(env, home);
+	return (is_error);
+}
+
+int	execute_home(t_cmd *cmd_list, char ***env, char *home, char *path)
+{
+	int	is_error;
+
+	is_error = EXIT_FAILURE;
+	if (cmd_list->cmdline[1].cmd[0] == '~')
+	{
+		path = ft_strjoin(home, cmd_list->cmdline[1].cmd + 1);
+		if (ft_strlen(cmd_list->cmdline[1].cmd) == 1)
+			is_error = execute_chdir(env, home);
+		else
+			is_error = execute_chdir(env, path);
+	}
+	if (path)
+		free(path);
+	return (is_error);
+}
+
+int	ft_cd(t_cmd *cmd, char ***env)
+{
+	char	*home;
+	char	*path;
+	int		is_error;
+
+	home = getenv("HOME");
+	path = NULL;
+	
+	if (get_cmd_size(cmd) == 1)
+		is_error = execute_none_option(cmd, env, home);
+	else if (cmd->cmdline[1].cmd[0] == '~')
+		is_error = execute_home(cmd, env, home, path);
+	else 
+		is_error = execute_env(cmd, env, home, path);
+	return  (is_error);
+}

--- a/srcs/execute/ft_cd_util.c
+++ b/srcs/execute/ft_cd_util.c
@@ -1,0 +1,38 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_cd_util.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/05/14 00:00:07 by hkim2             #+#    #+#             */
+/*   Updated: 2022/05/14 00:00:21 by hkim2            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/minishell.h"
+
+int	print_cd_error(char *cmd)
+{
+	ft_putstr_fd("cd: no such file or directory: ", 2);
+	ft_putendl_fd(cmd, 2);
+	return (EXIT_FAILURE);
+}
+
+int	add_cd_env(char *current_pwd, char *old_pwd, char ***env)
+{
+	char	*env_pwd;
+	char	*env_old_pwd;
+		
+	env_pwd = ft_strjoin("PWD=", current_pwd);
+	if (!env_pwd)
+		return (EXIT_FAILURE);
+	env_old_pwd = ft_strjoin("OLDPWD=", old_pwd);
+	if (!env_old_pwd)
+		return (EXIT_FAILURE);
+	add_env(env_pwd, env);
+	add_env(env_old_pwd, env);
+	free(env_old_pwd);
+	free(env_pwd);
+	return (EXIT_SUCCESS);
+}

--- a/srcs/execute/ft_cd_util.c
+++ b/srcs/execute/ft_cd_util.c
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/14 00:00:07 by hkim2             #+#    #+#             */
-/*   Updated: 2022/05/14 00:00:21 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/14 20:13:10 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,8 +30,14 @@ int	add_cd_env(char *current_pwd, char *old_pwd, char ***env)
 	env_old_pwd = ft_strjoin("OLDPWD=", old_pwd);
 	if (!env_old_pwd)
 		return (EXIT_FAILURE);
-	add_env(env_pwd, env);
-	add_env(env_old_pwd, env);
+	if (add_env(env_pwd, env) || add_env(env_old_pwd, env))
+	{
+		ft_putendl_fd("cd : set env error", 2);
+		if (env_old_pwd)
+			free(env_old_pwd);
+		if (env_pwd)
+			free(env_pwd);
+	}
 	free(env_old_pwd);
 	free(env_pwd);
 	return (EXIT_SUCCESS);

--- a/srcs/execute/ft_echo.c
+++ b/srcs/execute/ft_echo.c
@@ -1,0 +1,77 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_echo.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/05/14 20:31:10 by hkim2             #+#    #+#             */
+/*   Updated: 2022/05/14 21:52:59 by hkim2            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/minishell.h"
+
+int	check_newline(char *cmd)
+{
+	int	len;
+
+	len = ft_strlen(cmd);
+	if (len != 2)
+		return (1);
+	if (ft_strncmp(cmd, "-n", 2) != 0)
+		return (1);
+	return (0);
+}
+
+void	print_echo(t_cmd *cmd_list)
+{
+	int		i;
+	char	*cmd;
+
+	i = 1;
+	while (cmd_list->cmdline[i].cmd)
+	{
+		cmd = cmd_list->cmdline[i].cmd;
+		ft_putstr_fd(cmd, STDOUT);
+		if (cmd_list->cmdline[i + 1].cmd)
+			ft_putstr_fd(" ", STDOUT);
+		i++;
+	}
+}
+
+void	print_echo_no_newline(t_cmd *cmd_list)
+{
+	int		i;
+	char	*cmd;
+
+	i = 2;
+	while (cmd_list->cmdline[i].cmd)
+	{
+		cmd = cmd_list->cmdline[i].cmd;
+		ft_putstr_fd(cmd, STDOUT);
+		if (cmd_list->cmdline[i + 1].cmd)
+			ft_putstr_fd(" ", STDOUT);
+		i++;
+	}
+}
+
+int	ft_echo(t_cmd *cmd_list)
+{
+	int		newline_flag;
+
+	if (get_cmd_size(cmd_list) == 1)
+	{
+		ft_putstr_fd("\n", STDOUT);
+		return (EXIT_SUCCESS);
+	}
+	newline_flag = check_newline(cmd_list->cmdline[1].cmd);
+	if (newline_flag)
+	{
+		print_echo(cmd_list);
+		ft_putstr_fd("\n", STDOUT);
+	}
+	else
+		print_echo_no_newline(cmd_list);
+	return (EXIT_SUCCESS);
+}

--- a/srcs/execute/ft_env.c
+++ b/srcs/execute/ft_env.c
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/11 17:53:42 by hkim2             #+#    #+#             */
-/*   Updated: 2022/05/12 18:24:52 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/13 18:40:32 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@ int	ft_env(char **env)
 	while (env[i])
 	{
 		if (ft_strchr(env[i], '='))
-			ft_putendl_fd(env[i], STDOUT_FILENO);
+			ft_putendl_fd(env[i], STDOUT);
 		i++;
 	}
 	return (0);

--- a/srcs/execute/ft_exit.c
+++ b/srcs/execute/ft_exit.c
@@ -1,0 +1,74 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_exit.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/05/14 21:57:51 by hkim2             #+#    #+#             */
+/*   Updated: 2022/05/14 23:37:35 by hkim2            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/minishell.h"
+
+int		is_numeric(char *cmd)
+{
+	int	i;
+
+	i = 0;
+	while(cmd[i])
+	{
+		if (!ft_isdigit(cmd[i]))
+			return (0);
+		i++;
+	}
+	return (1);
+}
+
+void	print_exit_numeric(char *cmd)
+{
+	ft_putendl_fd("exit", STDERR);
+	ft_putstr_fd("bash: exit: ", STDERR);
+	ft_putstr_fd(cmd, STDERR);
+	ft_putendl_fd(": numeric argument required", STDERR);
+}
+
+void	print_exit_many_arg()
+{
+	ft_putendl_fd("exit", STDERR);
+	ft_putendl_fd("bash: exit: too many arguments", STDERR);
+}
+
+int		execute_exit(t_cmd *cmd_list)
+{
+	int	num;
+	
+	if (!is_numeric(cmd_list->cmdline[1].cmd))
+	{
+		print_exit_numeric(cmd_list->cmdline[1].cmd);
+		exit(255);
+	}
+	else if (get_cmd_size(cmd_list) > 2)
+	{
+		print_exit_many_arg();
+		return (EXIT_SUCCESS);
+	}
+	ft_putendl_fd("exit", STDOUT);
+	num = ft_atoi(cmd_list->cmdline[1].cmd, NULL) % 256;
+	exit(num);
+}
+
+int	ft_exit(t_cmd *cmd_list)
+{
+	int	is_error;
+
+	is_error = EXIT_SUCCESS;
+	if (get_cmd_size(cmd_list) == 1)
+	{
+		ft_putendl_fd("exit", STDOUT);
+		exit(EXIT_SUCCESS);
+	}
+	is_error = execute_exit(cmd_list);
+	return (is_error);
+}

--- a/srcs/execute/ft_export.c
+++ b/srcs/execute/ft_export.c
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/11 18:58:49 by hkim2             #+#    #+#             */
-/*   Updated: 2022/05/14 00:01:49 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/14 20:21:31 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,29 +44,15 @@ void	print_export_error(char *cmd)
 
 int	add_env(char *cmd, char ***env)
 {
-	int		i;
-	char	**tmp;
-	int		len; 
-	
-	//이부분은 반환 분기가 3개 이므로 수정할 것
-	if (add_duplicate_key(cmd, env) < 2)
+	int	is_error;
+
+	is_error = add_duplicate_key(cmd, env);
+	if (is_error == EXIT_SUCCESS)
+		return (EXIT_SUCCESS);
+	if (is_error == EXIT_FAILURE)
 		return (EXIT_FAILURE);
-	len = 0;
-	i = 0;
-	while ((*env)[len])
-		len++;
-	tmp = (char **)malloc(sizeof(char *) * len + sizeof(char *) * 2);
-	i = 0;
-	while (i < len)
-	{
-		tmp[i] = ft_strdup((*env)[i]);
-		i++;
-	}
-	tmp[len] = ft_strdup(cmd);
-	tmp[len + 1] = NULL;
-	free(*env);
-	(*env) = tmp;
-	return (EXIT_SUCCESS);
+	is_error = add_new_value(cmd, env);
+	return (is_error);
 }
 
 int	valid_cmd(char *cmd)
@@ -116,7 +102,7 @@ int	ft_export(t_cmd *cmd_list, char ***env)
 			is_error = EXIT_SUCCESS;
 		}
 		else
-			return  (add_env(cmd, env));
+			is_error = add_env(cmd, env);
 		free(cmd);
 	}
 	return (is_error);

--- a/srcs/execute/ft_export.c
+++ b/srcs/execute/ft_export.c
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/11 18:58:49 by hkim2             #+#    #+#             */
-/*   Updated: 2022/05/13 18:59:01 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/14 00:01:49 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,7 +48,8 @@ int	add_env(char *cmd, char ***env)
 	char	**tmp;
 	int		len; 
 	
-	if (!add_duplicate_key(cmd, env))
+	//이부분은 반환 분기가 3개 이므로 수정할 것
+	if (add_duplicate_key(cmd, env) < 2)
 		return (EXIT_FAILURE);
 	len = 0;
 	i = 0;
@@ -115,7 +116,7 @@ int	ft_export(t_cmd *cmd_list, char ***env)
 			is_error = EXIT_SUCCESS;
 		}
 		else
-			add_env(cmd, env);
+			return  (add_env(cmd, env));
 		free(cmd);
 	}
 	return (is_error);

--- a/srcs/execute/ft_export.c
+++ b/srcs/execute/ft_export.c
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/11 18:58:49 by hkim2             #+#    #+#             */
-/*   Updated: 2022/05/12 23:32:29 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/13 18:59:01 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,15 +42,30 @@ void	print_export_error(char *cmd)
 	ft_putstr_fd("'\n", 2);
 }
 
-void	add_env(char *cmd, char ***env)
+int	add_env(char *cmd, char ***env)
 {
-	int	i;
-
+	int		i;
+	char	**tmp;
+	int		len; 
+	
+	if (!add_duplicate_key(cmd, env))
+		return (EXIT_FAILURE);
+	len = 0;
 	i = 0;
-	while ((*env)[i])
+	while ((*env)[len])
+		len++;
+	tmp = (char **)malloc(sizeof(char *) * len + sizeof(char *) * 2);
+	i = 0;
+	while (i < len)
+	{
+		tmp[i] = ft_strdup((*env)[i]);
 		i++;
-	(*env)[i] = ft_strdup(cmd);
-	(*env)[i + 1] = NULL;
+	}
+	tmp[len] = ft_strdup(cmd);
+	tmp[len + 1] = NULL;
+	free(*env);
+	(*env) = tmp;
+	return (EXIT_SUCCESS);
 }
 
 int	valid_cmd(char *cmd)

--- a/srcs/execute/ft_export_util.c
+++ b/srcs/execute/ft_export_util.c
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/12 21:43:58 by hkim2             #+#    #+#             */
-/*   Updated: 2022/05/13 23:53:04 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/14 20:18:00 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,11 +64,36 @@ int	add_duplicate_key(char *cmd, char ***env)
 
 	key_index = get_duplicate_index(cmd, *env);
 	if (key_index == -1)
-		return (2);
+		return (-1);
 	tmp = ft_strdup(cmd);
 	if (!tmp)
 		return (EXIT_FAILURE);
 	free((*env)[key_index]);
 	(*env)[key_index] = tmp;
+	return (EXIT_SUCCESS);
+}
+
+int	add_new_value(char *cmd, char ***env)
+{
+	int		i;
+	char	**tmp;
+	int		len; 
+	
+	len = 0;
+	while ((*env)[len])
+		len++;
+	tmp = (char **)malloc(sizeof(char *) * len + sizeof(char *) * 2);
+	if (!tmp)
+		return (EXIT_FAILURE);
+	i = 0;
+	while (i < len)
+	{
+		tmp[i] = ft_strdup((*env)[i]);
+		i++;
+	}
+	tmp[len] = ft_strdup(cmd);
+	tmp[len + 1] = NULL;
+	free(*env);
+	(*env) = tmp;
 	return (EXIT_SUCCESS);
 }

--- a/srcs/execute/ft_export_util.c
+++ b/srcs/execute/ft_export_util.c
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/12 21:43:58 by hkim2             #+#    #+#             */
-/*   Updated: 2022/05/13 18:59:08 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/13 23:53:04 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,7 +64,7 @@ int	add_duplicate_key(char *cmd, char ***env)
 
 	key_index = get_duplicate_index(cmd, *env);
 	if (key_index == -1)
-		return (EXIT_FAILURE);
+		return (2);
 	tmp = ft_strdup(cmd);
 	if (!tmp)
 		return (EXIT_FAILURE);

--- a/srcs/execute/ft_export_util.c
+++ b/srcs/execute/ft_export_util.c
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/12 21:43:58 by hkim2             #+#    #+#             */
-/*   Updated: 2022/05/12 23:00:42 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/13 18:59:08 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,4 +32,43 @@ int	is_vaild_word(char c)
 	if (c == '_')
 		return (1);
 	return (0);
+}
+
+int	get_duplicate_index(char *cmd, char **env)
+{
+	int		i;
+	char	**split;
+	char	**split_cmd;
+
+	split_cmd = ft_split(cmd, '=');
+	if (!split_cmd)
+		return (-1);
+	i = 0;
+	while (env[i])
+	{
+		split = ft_split(env[i], '=');
+		if (!split)
+			return (-1);
+		if (ft_strlen(split[0]) == ft_strlen(split_cmd[0]))
+			if (ft_strncmp(split[0], split_cmd[0], ft_strlen(split_cmd[0])) == 0)
+				return (i);
+		i++;
+	}
+	return (-1);
+}
+
+int	add_duplicate_key(char *cmd, char ***env)
+{
+	char	*tmp;
+	int		key_index;
+
+	key_index = get_duplicate_index(cmd, *env);
+	if (key_index == -1)
+		return (EXIT_FAILURE);
+	tmp = ft_strdup(cmd);
+	if (!tmp)
+		return (EXIT_FAILURE);
+	free((*env)[key_index]);
+	(*env)[key_index] = tmp;
+	return (EXIT_SUCCESS);
 }

--- a/srcs/execute/ft_pwd.c
+++ b/srcs/execute/ft_pwd.c
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/12 18:19:28 by hkim2             #+#    #+#             */
-/*   Updated: 2022/05/12 21:51:05 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/13 18:06:55 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,13 +19,12 @@ int		ft_pwd(t_cmd *cmd_list)
 	
 	if (get_cmd_size(cmd_list) > 1 && !is_redirection(cmd_list->cmdline[1].cmd) )
 	{
-		ft_putendl_fd("pwd: too many arguments\n", STDERR);
+		ft_putendl_fd("pwd: too many arguments", STDERR);
 		return (EXIT_FAILURE);
 	}
 	if (getcwd(buf, 1024))
 	{
 		ft_putendl_fd(buf, STDOUT);
-		ft_putendl_fd("\n", STDOUT);
 		return (EXIT_SUCCESS);
 	}
 	else

--- a/srcs/execute/ft_unset.c
+++ b/srcs/execute/ft_unset.c
@@ -6,14 +6,111 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/12 22:12:29 by hkim2             #+#    #+#             */
-/*   Updated: 2022/05/12 22:20:22 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/13 19:04:48 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 # include "../../includes/minishell.h"
 
+void	print_unset_error(char *cmd)
+{
+	ft_putstr_fd("unset: ", 2);
+	ft_putstr_fd(cmd, 2);
+	ft_putstr_fd(" invalid parameter name\n", 2);
+}
+
+int	valid_unset_cmd(char *cmd)
+{
+	int		i;
+	int		len;
+	
+	if (!is_vaild_word(cmd[0]))
+		return (EXIT_FAILURE);
+	len = ft_strlen(cmd);
+	i = 1;
+	while (i < len)
+	{
+		if (!is_vaild_word(cmd[i]) && !ft_isdigit(cmd[i]))
+			return (EXIT_FAILURE);
+		i++;
+	}
+	return (EXIT_SUCCESS);
+}
+
+
+void	remove_env(char *cmd, char ***env)
+{
+	char	**tmp;
+	int		i;
+	int		len;
+	int		re_index;
+
+	len = 0;
+	while ((*env)[len])
+		len++;
+	tmp = (char **)malloc(sizeof(char *) * len);
+	i = -1;
+	len = 0;
+	re_index = get_removal_index(cmd, *env);	
+	while ((*env)[++i])
+	{
+		if (re_index == i)
+			continue;
+		tmp[len++] = ft_strdup((*env)[i]);
+	}
+	tmp[len] = NULL;
+	i = 0;
+	while ((*env)[i])
+		free((*env)[i++]);
+	free(*env);
+	(*env) = tmp;
+}
+
+int	get_removal_index(char *cmd, char **env)
+{
+	int		i;
+	char	**split;
+
+	i = 0;
+	while (env[i])
+	{
+		split = ft_split(env[i], '=');
+		if (!split)
+			return (-1);
+		if (ft_strlen(split[0]) == ft_strlen(cmd))
+		{
+			if (ft_strncmp(split[0], cmd, ft_strlen(cmd)) == 0)
+				return (i);
+		}
+		free_split_str(split);
+		i++;
+	}
+	return (-1);
+}
+
 int	ft_unset(t_cmd *cmd_list, char ***env)
 {
+	char	*cmd;
+	int		i;
+	int		is_error;
+	
+	is_error = EXIT_SUCCESS;
 	if (get_cmd_size(cmd_list) == 1)
 		return (EXIT_SUCCESS);
+	i = 1;
+	while (cmd_list->cmdline[i].cmd)
+	{
+		cmd = ft_strdup(cmd_list->cmdline[i].cmd);
+		if (!cmd)
+			return (EXIT_FAILURE);
+		if (valid_unset_cmd(cmd))
+		{
+			print_unset_error(cmd);
+			is_error = EXIT_FAILURE;
+		}
+		else if (get_removal_index(cmd, *env) != -1)
+			remove_env(cmd, env);
+		i++;
+	}
+	return (is_error);
 }


### PR DESCRIPTION
## ft_exit
- `exit` - 종료코드 0으로 종료합니다
- `exit 문자 arg1 arg2` - 첫 번째 인자로 숫자가 아닌 값이오면(-, +포함)
     - `bash: exit: a: numeric argument required` 문구룰 출력후 `255` 종료코드로 종료합니다
- `exit 숫자` - 인자로 들어온 값으로 종료합니다. (256값을 초과하면 256로 나눈 나머지로 출력)
- `exit 숫자 arg1 arg2` - `bash: exit: too many arguments` 문구를 출력후 종료하지 않습니다
