### PR TITLE
[parser] quote ' " 같이 사용시 발생 문제 해결

### DIFF
--- a/srcs/parser/assign_output_token.c
+++ b/srcs/parser/assign_output_token.c
@@ -33,25 +33,34 @@ int	ft_assign_env(char *in_tok, char **out_token, char **envp)
 	return (in_tok_idx);
 }
 
-int	ft_quote_assign_and_cnt(char *in_tok, char **out_token, char **envp)
+void	*ft_out_tok_assign_cnt(char **out_tok, char *in_tok, int *in_tok_idx)
+{
+	**out_tok = in_tok[*in_tok_idx];
+	(*out_tok)++;
+	(*in_tok_idx)++;
+	return (0);
+}
+
+int	ft_quote_assign_and_cnt(char *in_tok, char **out_tok, char **envp, char q)
 {
 	int	in_tok_idx;
 
 	in_tok_idx = 1;
-	while (in_tok[in_tok_idx] && \
-	(in_tok[in_tok_idx] != '\"' && \
-	in_tok[in_tok_idx] != '\''))
+	if (q == '\"')
 	{
-		if (in_tok[in_tok_idx] == '$' && \
-		in_tok[in_tok_idx - 1] == '\"')
-			in_tok_idx += (ft_assign_env(&in_tok[in_tok_idx], \
-			out_token, envp) + 1);
-		else
+		while (in_tok[in_tok_idx] && in_tok[in_tok_idx] != '\"')
 		{
-			**out_token = in_tok[in_tok_idx];
-			(*out_token)++;
-			in_tok_idx++;
+			if (in_tok[in_tok_idx] == '$')
+				in_tok_idx += (ft_assign_env(&in_tok[in_tok_idx], \
+				out_tok, envp) + 1);
+			else
+				ft_out_tok_assign_cnt(out_tok, in_tok, &in_tok_idx);
 		}
+	}
+	else if (q == '\'')
+	{
+		while (in_tok[in_tok_idx] && in_tok[in_tok_idx] != '\'')
+			ft_out_tok_assign_cnt(out_tok, in_tok, &in_tok_idx);
 	}
 	return (in_tok_idx);
 }
@@ -68,11 +77,11 @@ void	*ft_assign_output_token(char *in_tok, char *out_tok, char **ev)
 	while (in_tok[++i])
 	{
 		if (in_tok[i] == '\'' && \
-		ft_is_closed_quote(&in_tok[i], '\'') == CLOSED)
-			i += ft_quote_assign_and_cnt(&in_tok[i], &out_tok_tmp, ev);
+			ft_is_closed_quote(&in_tok[i], '\'') == CLOSED)
+			i += ft_quote_assign_and_cnt(&in_tok[i], &out_tok_tmp, ev, '\'');
 		else if (in_tok[i] == '\"' && \
-		ft_is_closed_quote(&in_tok[i], '\"') == CLOSED)
-			i += ft_quote_assign_and_cnt(&in_tok[i], &out_tok_tmp, ev);
+			ft_is_closed_quote(&in_tok[i], '\"') == CLOSED)
+			i += ft_quote_assign_and_cnt(&in_tok[i], &out_tok_tmp, ev, '\"');
 		else if (in_tok[i] == '$')
 			i += ft_assign_env(&in_tok[i], &out_tok_tmp, ev);
 		else if (in_tok[i])

--- a/srcs/parser/output_token_len.c
+++ b/srcs/parser/output_token_len.c
@@ -6,7 +6,7 @@
 /*   By: jeonghwl <jeonghwl@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/11 13:55:51 by jeonghwl          #+#    #+#             */
-/*   Updated: 2022/05/11 13:55:53 by jeonghwl         ###   ########.fr       */
+/*   Updated: 2022/05/18 10:51:17 by jeonghwl         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,18 +47,27 @@ int	ft_env_cnt(char *token, int *count, char **envp)
 	return (key_len);
 }
 
-int	ft_quote_cnt(char *token, int *count, char **envp)
+int	ft_quote_cnt(char *token, int *count, char **envp, char q)
 {
 	int	index;
 
 	index = 1;
-	while (token[index] && (token[index] != '\"' || token[index] != '\''))
+	if (q == '\"')
 	{
-		if (token[index] == '$' && token[index - 1] == '\"')
+		while (token[index] && (token[index] != '\"'))
 		{
-			index += (ft_env_cnt(&token[index], count, envp) + 1);
+			if (token[index] == '$')
+				index += (ft_env_cnt(&token[index], count, envp) + 1);
+			else
+			{
+				index++;
+				(*count)++;
+			}
 		}
-		else
+	}
+	else if (q == '\'')
+	{
+		while (token[index] && (token[index] != '\''))
 		{
 			index++;
 			(*count)++;
@@ -77,11 +86,11 @@ int	ft_output_token_len(char *token, char **envp)
 	while (token[++index])
 	{
 		if (token[index] == '\'' && \
-		ft_is_closed_quote(&token[index], '\'') == CLOSED)
-			index += ft_quote_cnt(&token[index], &count, envp);
+			ft_is_closed_quote(&token[index], '\'') == CLOSED)
+			index += ft_quote_cnt(&token[index], &count, envp, '\'');
 		else if (token[index] == '\"' && \
-		ft_is_closed_quote(&token[index], '\"') == CLOSED)
-			index += ft_quote_cnt(&token[index], &count, envp);
+			ft_is_closed_quote(&token[index], '\"') == CLOSED)
+			index += ft_quote_cnt(&token[index], &count, envp, '\"');
 		else if (token[index] == '$')
 			index += ft_env_cnt(&token[index], &count, envp);
 		else if (token[index])


### PR DESCRIPTION
기존 parser 코드에서 
'과 "를 같이 사용시 값 누락, 
" 사용시 $환경변수 작동되지 않던 문제 있었습니다.

"echo 메시지 -> 결과 " 가 
아래처럼 나오도록 parse 부분 코드 수정했습니다.


echo '"hi"' -> "hi"
echo "'hi'" -> 'hi'
echo "'$USER'" -> 'jeonghwl'
echo '"$USER"' -> "$USER"
echo "               $USER" ->                jeonghwl

