### PR TITLE
Add. redirection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/05/12 14:11:43 by jeonghwl          #+#    #+#              #
-#    Updated: 2022/05/18 15:50:04 by hkim2            ###   ########.fr        #
+#    Updated: 2022/05/19 23:18:33 by hkim2            ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -49,6 +49,8 @@ SRC 		= 	srcs/ft_tmp.c \
 				srcs/execute/ft_cd_util.c \
 				srcs/execute/ft_echo.c \
 				srcs/execute/ft_exit.c \
+				srcs/execute/redirection.c \
+				srcs/execute/redirection_util.c \
 				
 OBJ_DIR 	= objs
 OBJ 		= $(SRC:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/11 13:57:07 by jeonghwl          #+#    #+#             */
-/*   Updated: 2022/05/18 17:01:32 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/19 23:22:38 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,9 +45,7 @@
 # define CLOSED 1
 # define UNCLOSED 0
 
-# define CD_ERROR 0
-# define CD_HOME 1
-# define CD_ARG 2
+# define HEREDOC ".heredoc_tmp"
 
 extern int	g_exit_status;
 
@@ -263,4 +261,17 @@ int					execute_exit(t_cmd *cmd_list);
 void				print_exit_many_arg();
 void				print_exit_numeric(char *cmd);
 int					is_numeric(char *cmd);
+
+//execute/redirection.c
+int					redirewction_out(t_token *cmdline, int i);
+int					redirection_in(t_token *cmdline, int i);
+int					redirection_out_append(t_token *cmdline, int i);
+int					redirection_heredoc(t_token *cmdline, int i);
+int					set_redirection(t_token *cmdline, int i);
+
+//execute/redirection_util.c
+int					parse_cmd_without_ridir(t_cmd *cmd_list, int non_redir_count);
+int					check_redirection(t_cmd *cmd_list);
+int					pre_check(t_cmd *cmd_list);
+int					print_syntax_error();
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/11 13:57:07 by jeonghwl          #+#    #+#             */
-/*   Updated: 2022/05/19 23:22:38 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/19 23:30:03 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -189,7 +189,7 @@ void				ft_parse(t_cmd **cmd_list, char *line, char **envp);
 //execute header
 
 //execute/execute.c
-void				execute(t_cmd *cmd_list, char ***env);
+int					execute(t_cmd *cmd_list, char ***env);
 void				execute_cmd_pipe(t_cmd *cmd_list, char ***env);
 void				execute_builtin_pipe(t_cmd *cmd_list, char ***env);
 int					execute_builtin(t_cmd *cmd_list, char ***env, int stdin_dup, int stdout_dup);

--- a/srcs/execute/execute.c
+++ b/srcs/execute/execute.c
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/10 19:43:23 by hkim2             #+#    #+#             */
-/*   Updated: 2022/05/18 15:48:27 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/19 23:21:54 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -107,15 +107,15 @@ void	execute_cmd(t_cmd *cmd_list, char ***env, int stdin_dup, int stdout_dup)
 
 void	execute(t_cmd *cmd_list, char ***env)
 {
-	int		i;
 	int		stdin_dup;
 	int		stdout_dup;
 	
 	stdin_dup = dup(0);
 	stdout_dup = dup(1);
 	while (cmd_list)
-	{	
-		pipe(cmd_list->pip);	
+	{
+		pipe(cmd_list->pip);
+		pre_check(cmd_list);
 		if (cmd_list->pipe_flag)
 		{	
 			if (is_builtin(cmd_list->cmdline[0].cmd))

--- a/srcs/execute/execute.c
+++ b/srcs/execute/execute.c
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/10 19:43:23 by hkim2             #+#    #+#             */
-/*   Updated: 2022/05/19 23:21:54 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/19 23:30:17 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -105,7 +105,7 @@ void	execute_cmd(t_cmd *cmd_list, char ***env, int stdin_dup, int stdout_dup)
 	}
 }
 
-void	execute(t_cmd *cmd_list, char ***env)
+int	execute(t_cmd *cmd_list, char ***env)
 {
 	int		stdin_dup;
 	int		stdout_dup;
@@ -115,7 +115,8 @@ void	execute(t_cmd *cmd_list, char ***env)
 	while (cmd_list)
 	{
 		pipe(cmd_list->pip);
-		pre_check(cmd_list);
+		if (pre_check(cmd_list))
+			return (EXIT_FAILURE);
 		if (cmd_list->pipe_flag)
 		{	
 			if (is_builtin(cmd_list->cmdline[0].cmd))
@@ -132,5 +133,5 @@ void	execute(t_cmd *cmd_list, char ***env)
 		}
 		cmd_list = cmd_list->next;
 	}	
-	return ;
+	return (EXIT_SUCCESS);
 }

--- a/srcs/execute/redirection.c
+++ b/srcs/execute/redirection.c
@@ -1,0 +1,109 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   redirection.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/05/19 23:13:05 by hkim2             #+#    #+#             */
+/*   Updated: 2022/05/19 23:23:02 by hkim2            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+# include "../../includes/minishell.h"
+
+int	redirection_out(t_token *cmdline, int i)
+{
+	int	fd;
+
+	fd = open(cmdline[i + 1].cmd, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+	if (fd == -1)
+	{
+		ft_putendl_fd(strerror(errno), 2);
+		return (EXIT_FAILURE);
+	}
+	dup2(fd, STDOUT_FILENO);
+	close(fd);
+	cmdline[i + 1].redir_flag = 1;
+	return (EXIT_SUCCESS);
+}
+
+int	redirection_in(t_token *cmdline, int i)
+{
+	int	fd;
+
+	fd = open(cmdline[i + 1].cmd, O_RDONLY);
+	if (fd == -1)
+	{
+		ft_putendl_fd(strerror(errno), 2);
+		return (EXIT_FAILURE);
+	}
+	dup2(fd, STDIN_FILENO);
+	close(fd);
+	cmdline[i + 1].redir_flag = 1;
+	return (EXIT_SUCCESS);
+}
+
+int	redirection_out_append(t_token *cmdline, int i)
+{
+	int	fd;
+
+	fd = open(cmdline[i + 1].cmd, O_CREAT | O_WRONLY | O_APPEND, 0644);
+	if (fd == -1)
+	{
+		ft_putendl_fd(strerror(errno), 2);
+		return (EXIT_FAILURE);
+	}
+	dup2(fd, STDOUT_FILENO);
+	close(fd);
+	cmdline[i + 1].redir_flag = 1;
+	return (EXIT_SUCCESS);
+}
+
+
+int	redirection_heredoc(t_token *cmdline, int i)
+{
+	int		fd;
+	int		*str;
+
+	fd = open(HEREDOC, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+	if (fd == -1)
+	{
+		ft_putendl_fd(strerror(errno), 2);
+		return (EXIT_FAILURE);
+	}
+	while (1)
+	{
+		str = readline("> ");
+		if (str)
+			if (ft_strncmp(str, cmdline[i + 1].cmd, ft_strlen(cmdline[i + 1].cmd)) == 0)
+				break;
+		ft_putendl_fd(str, fd);
+		free(str);
+	}
+	close(fd);
+	fd = open(HEREDOC, O_RDONLY, 0644);
+	if (fd == -1)
+	{
+		ft_putendl_fd(strerror(errno), 2);
+		return (EXIT_FAILURE);
+	}
+	dup2(fd, STDIN_FILENO);
+	close(fd);
+	cmdline[i + 1].redir_flag = 1;
+	return (EXIT_SUCCESS);
+}
+
+int	set_redirection(t_token *cmdline, int i)
+{
+	if (ft_strlen(cmdline[i].cmd) > 2)
+		return (EXIT_FAILURE);
+	if (ft_strncmp(cmdline[i].cmd, ">", 2) == 0)
+		return (redirection_out(cmdline, i));
+	else if (ft_strncmp(cmdline[i].cmd, "<<", 3) == 0)
+		return (redirection_heredoc(cmdline, i));
+	else if (ft_strncmp(cmdline[i].cmd, ">>", 3) == 0)
+		return (redirection_out_append(cmdline, i));
+	else if (ft_strncmp(cmdline[i].cmd, "<", 2) == 0)
+		return (redirection_in(cmdline, i));
+}

--- a/srcs/execute/redirection_util.c
+++ b/srcs/execute/redirection_util.c
@@ -1,0 +1,78 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   redirection_util.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/05/19 23:17:21 by hkim2             #+#    #+#             */
+/*   Updated: 2022/05/19 23:22:13 by hkim2            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+# include "../../includes/minishell.h"
+
+int	parse_cmd_without_ridir(t_cmd *cmd_list, int non_redir_count)
+{
+	t_token	*tmp;
+	int		i;
+	int		len;
+
+	tmp = (t_token *)malloc(sizeof(t_token) * (non_redir_count + 3));
+	i = 0;
+	len = 0;
+	while (cmd_list->cmdline[i].cmd)
+	{
+		if (!cmd_list->cmdline[i].redir_flag)
+		{
+			tmp[len].cmd = ft_strdup(cmd_list->cmdline[i].cmd);
+			tmp[len++].redir_flag = 0;
+		}
+		i++;
+	}
+	tmp[len].cmd = NULL;
+	tmp[len].redir_flag = 0;
+	free(cmd_list->cmdline);
+	cmd_list->cmdline = tmp;
+	return (EXIT_SUCCESS);
+}
+
+int	check_redirection(t_cmd *cmd_list)
+{
+	int	i;
+	int	non_redir_count;
+
+	non_redir_count = 0;
+	i = 0;
+	while (cmd_list->cmdline[i].cmd)
+	{
+		if (cmd_list->cmdline[i].redir_flag)
+		{
+			if (cmd_list->cmdline[i + 1].cmd == NULL || cmd_list->cmdline[i + 1].redir_flag)
+				return (print_syntax_error());
+			else
+			{
+				set_redirection(cmd_list->cmdline, i);
+				i++;
+			}
+		}
+		else
+			non_redir_count++;
+		i++;
+	}
+	
+	parse_cmd_without_ridir(cmd_list, non_redir_count);
+	i = 0;
+	return (EXIT_SUCCESS);
+}
+
+int	pre_check(t_cmd *cmd_list)
+{
+	if (check_redirection(cmd_list))
+		return (EXIT_FAILURE);
+}
+
+int	print_syntax_error()
+{
+	ft_putendl_fd("Syntax Error\n", STDERR);
+}

--- a/srcs/execute/redirection_util.c
+++ b/srcs/execute/redirection_util.c
@@ -6,7 +6,7 @@
 /*   By: hkim2 <hkim2@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/19 23:17:21 by hkim2             #+#    #+#             */
-/*   Updated: 2022/05/19 23:22:13 by hkim2            ###   ########.fr       */
+/*   Updated: 2022/05/19 23:30:31 by hkim2            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,5 +74,5 @@ int	pre_check(t_cmd *cmd_list)
 
 int	print_syntax_error()
 {
-	ft_putendl_fd("Syntax Error\n", STDERR);
+	ft_putendl_fd("Syntax Error", STDERR);
 }


### PR DESCRIPTION
## 리다이렉션
- `<` - 앞에 나온 명령의 입력으로 들어갑니다
    - ex) `cat < a` - `a`파일이 입력으로 들어갑니다.
- `>` - 앞에 있는 명령의 결과를 뒤에 있는 파일에 저장합니다.
    - ex) `cat a > test.text` - a를 출력한 결과가 `test.text` 파일에 들어갑니다
- `>>` - 앞에 있는 명령의 결과를 뒤에 `추가`합니다
    - ex) `cat a > test.text` - `test.text` 파일에 a를 출력한 결과가 추가됩니다
- `<<` - 뒤에있는 문자가 나오기 전까지 계속 입력을 받습니다
    - ex) `cat << test` - `test`가 입력되기 전까지 입력을 계속 받으며 종료되면 입력한 문자들이 뒤에 있는 명령의 입력으로 들어갑니다.